### PR TITLE
allow multiple sources in firewalld_zone_source

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following variables are used to define the source of a zone:
 ```
     firewalld_zone_source:
       public:
-        name: (required, zone name)
+        zone: (required, zone name)
         source: (required, array of sources e.g. [ 192.168.1.1/24, 10.16.16.23 ])
         state: (optional, only values: enabled|disabled, default: enabled)
         permanent: (optional, only values: true|false, default: true)
@@ -127,7 +127,7 @@ Example Playbook
           internal: eth2
         firewalld_zone_source:
           trusted:
-            name: trusted
+            zone: trusted
             source:
               - "192.168.1.0/24"
               - "10.0.16.12"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ The following variables are used to define the source of a zone:
 ```
     firewalld_zone_source:
       public:
-        source: (required, e.g. "192.168.1.0/24")
+        name: (required, zone name)
+        source: (required, array of sources e.g. [ 192.168.1.1/24, 10.16.16.23 ])
         state: (optional, only values: enabled|disabled, default: enabled)
         permanent: (optional, only values: true|false, default: true)
         immediate: (optional, only values: true|false, default: true)
@@ -126,7 +127,10 @@ Example Playbook
           internal: eth2
         firewalld_zone_source:
           trusted:
-            source: "192.168.1.0/24"
+            name: trusted
+            source:
+              - "192.168.1.0/24"
+              - "10.0.16.12"
             state: enabled
             permanent: true
             immediate: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,12 +34,14 @@
 
 - name: set firewalld zone source
   firewalld:
-    zone: "{{ item.key }}"
-    permanent: "{{ item.value.permanent|default('true') }}"
-    immediate: "{{ item.value.immediate|default('true') }}"
-    state: "{{ item.value.state|default('enabled') }}"
-    source: "{{ item.value.source }}"
-  with_dict: "{{ firewalld_zone_source|default({}) }}"
+    zone: "{{ item.0.name }}"
+    permanent: "{{ item.0.value.permanent|default('true') }}"
+    immediate: "{{ item.0.value.immediate|default('true') }}"
+    state: "{{ item.0.value.state|default('enabled') }}"
+    source: "{{ item.1 }}"
+  with_subelements:
+    - "{{ firewalld_zone_source|default({}) }}"
+    - "source"
   tags: firewalld
 
 - name: get active firewalld service rules

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: set firewalld zone source
   firewalld:
-    zone: "{{ item.0.name }}"
+    zone: "{{ item.0.zone }}"
     permanent: "{{ item.0.value.permanent|default('true') }}"
     immediate: "{{ item.0.value.immediate|default('true') }}"
     state: "{{ item.0.value.state|default('enabled') }}"


### PR DESCRIPTION
Will break existing playbooks however will allow the user to configure multiple sources for each zone in firewalld_zone_source.