### PR TITLE
Allow to configure the same service for different zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,6 @@ The following variable is used to define the default zone of firewalld:
 
 ---
 
-The following variables are used to define the interface of a zone (multiple interfaces per zone possible, one interface per line):
-
-```
-    firewalld_zone_interface:
-      public: (required, e.g. eth0)
-```
-
----
-
 The following variables are used to define the source of a zone:
 
 ```
@@ -85,6 +76,21 @@ The following variables are used to define a port rule:
         zone: (optional, default: public)
         permanent: (optional, only values: true|false, default: true)
         immediate: (optional, only values: true|false, default: true)
+```
+
+---
+
+The following variables are used to define which interfaces assigned to zones:
+
+```
+    firewalld_zone_interfaces:
+      - name: trusted
+        interfaces:
+          - eth1
+          - eth2
+      - name: public
+        interfaces:
+          - eth0
 ```
 
 ---

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,7 +63,7 @@
 
 - name: set firewalld service rules
   firewalld:
-    service: "{{ item.key }}"
+    service: "{{ item.value.service | default(item.key) }}"
     permanent: "{{ item.value.permanent|default('true') }}"
     immediate: "{{ item.value.immediate|default('true') }}"
     state: "{{ item.value.state|default('enabled') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,13 +20,15 @@
   changed_when: result.stdout == "success"
   tags: firewalld
 
-- name: set firewalld zone interface
+- name: set firewalld zone interfaces
   shell: |
-    if [[ "$(/bin/firewall-cmd --get-zone-of-interface={{ item.value }})" != "{{ item.key }}" ]]
+    if [[ "$(/bin/firewall-cmd --get-zone-of-interface={{ item.1 }})" != "{{ item.0.name }}" ]]
     then
-      /bin/firewall-cmd --zone={{ item.key }} --add-interface={{ item.value }} --permanent && echo "changed"
+      /bin/firewall-cmd --zone={{ item.0.name }} --add-interface={{ item.1 }} --permanent && echo "changed"
     fi
-  with_dict: "{{ firewalld_zone_interface|default({}) }}"
+  with_subelements: 
+    - "{{ firewalld_zone_interfaces|default([]) }}"
+    - interfaces
   register: shell_result
   changed_when: shell_result.stdout | join('') is search('changed')
   notify: restart firewalld


### PR DESCRIPTION
Allow to configure the same service for different zones.

For example, you need to allow the same service in the different zones.
If you will try to apply such configuration:
```
firewalld_service_rules:
    ssh:
        state: enabled
        zone: trusted
    ssh:
        state: enabled
        zone: public
```

You will receive this warning:

> [WARNING]: While constructing a mapping from firewalld.yml, line 5, column 3, found a duplicate dict key (ssh). Using last
> defined value only.

With this change you will able to use such configuration:
```
firewalld_service_rules:
    ssh_trusted:
        service: ssh
        state: enabled
        zone: trusted
    ssh_public:
        service: ssh
        state: enabled
        zone: public
```