### PR TITLE
Allow to purge all unconfigured ports and rename default zone variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ Config options:
 Requirements
 ------------
 
-Tested on RHEL 7, CentOS 7 and Fedora 29 only. 
+Tested on RHEL 7, CentOS 7 and Fedora 29 only.
 
-Ansible 2.0 or above 
+Ansible 2.0 or above
 
 Role Variables
 --------------
-**It is not necessary to use all these variable blocks, you can use only the config options you really need.** 
+**It is not necessary to use all these variable blocks, you can use only the config options you really need.**
 
 
 The following variable is used to define the default zone of firewalld:
 
 ```
-    default_zone: (optional, default: public)
+    firewalld_default_zone: (optional, default: public)
 ```
 
 ---
@@ -53,20 +53,20 @@ The following variables are used to define the source of a zone:
 
 ---
 
-The following variables are used to define a service rule: 
+The following variables are used to define a service rule:
 
 ```
-    firewalld_service_rules: 
+    firewalld_service_rules:
       service:
         state: (optional, only values: enabled|disabled, default: enabled)
-        zone: (optional, default: public) 
+        zone: (optional, default: public)
         permanent: (optional, only values: true|false, default: true)
         immediate: (optional, only values: true|false, default: true)
 ```
 
 ---
 
-The following variables are used to purge undefined active service rules: 
+The following variables are used to purge undefined active service rules:
 
 ```
     firewalld_purge_services: (optional, only values: true|false, default: false)
@@ -74,10 +74,10 @@ The following variables are used to purge undefined active service rules:
 
 ---
 
-The following variables are used to define a port rule: 
+The following variables are used to define a port rule:
 
 ```
-    firewalld_port_rules: 
+    firewalld_port_rules:
       name:
         port: (required, port or port range)
         protocol: (optional, only values: tcp|udp, default: tcp)
@@ -89,10 +89,10 @@ The following variables are used to define a port rule:
 
 ---
 
-The following variables are used to define a rich rule: 
+The following variables are used to define a rich rule:
 
 ```
-    firewalld_rich_rules: 
+    firewalld_rich_rules:
       name:
         rule: (required, a complete rule in firewalld rich language)
         state: (optional, only values: enabled|disabled, default: enabled)
@@ -119,7 +119,7 @@ Example Playbook
       roles:
         - ansible-firewalld-role
       vars:
-        default_zone: public
+        firewalld_default_zone: public
         firewalld_zone_interface:
           public: eth0
           internal: eth1
@@ -158,4 +158,3 @@ License
 -------
 
 MIT
-

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Role Variables
 The following variable is used to define the default zone of firewalld:
 
 ```
-    firewalld_default_zone: (optional, default: public)
+    default_zone: (optional, default: public)
 ```
 
 ---
@@ -119,7 +119,7 @@ Example Playbook
       roles:
         - ansible-firewalld-role
       vars:
-        firewalld_default_zone: public
+        default_zone: public
         firewalld_zone_interface:
           public: eth0
           internal: eth1

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The following variables are used to define a port rule:
 The following variables are used to define a rich rule:
 
 ```
-    firewalld_rich_rules:
+    firewalld_rich_rules: 
       name:
         rule: (required, a complete rule in firewalld rich language)
         state: (optional, only values: enabled|disabled, default: enabled)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,9 +14,9 @@
   tags: firewalld
 
 - name: set firewalld default zone
-  command: /bin/firewall-cmd --set-default-zone={{ default_zone|default('public') }}
+  command: /bin/firewall-cmd --set-default-zone={{ firewalld_default_zone|default('public') }}
   register: result
-  when: defaultzone.stdout != default_zone
+  when: defaultzone.stdout != firewalld_default_zone
   changed_when: result.stdout == "success"
   tags: firewalld
 
@@ -56,8 +56,27 @@
     permanent: true
     immediate: true
     state: disabled
-    zone: "{{ default_zone|default('public') }}"
+    zone: "{{ firewalld_default_zone|default('public') }}"
   with_items: "{{ active_services.stdout_lines }}"
+  when: firewalld_purge_services and item not in firewalld_service_rules
+  tags: firewalld
+
+- name: get active firewalld port rules
+  shell: set -o pipefail; /bin/firewall-cmd --list-ports | sed -e 's/ /\n/g'
+  args:
+    executable: /bin/bash
+  register: active_ports
+  changed_when: false
+  tags: firewalld
+
+- name: purge unconfigured firewalld port rules
+  firewalld:
+    service: "{{ item }}"
+    permanent: true
+    immediate: true
+    state: disabled
+    zone: "{{ firewalld_default_zone|default('public') }}"
+  with_items: "{{ active_ports.stdout_lines }}"
   when: firewalld_purge_services and item not in firewalld_service_rules
   tags: firewalld
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,7 +71,7 @@
 
 - name: purge unconfigured firewalld port rules
   firewalld:
-    service: "{{ item }}"
+    port: "{{ item }}"
     permanent: true
     immediate: true
     state: disabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,9 +14,9 @@
   tags: firewalld
 
 - name: set firewalld default zone
-  command: /bin/firewall-cmd --set-default-zone={{ firewalld_default_zone|default('public') }}
+  command: /bin/firewall-cmd --set-default-zone={{ default_zone|default('public') }}
   register: result
-  when: defaultzone.stdout != firewalld_default_zone
+  when: defaultzone.stdout != default_zone
   changed_when: result.stdout == "success"
   tags: firewalld
 
@@ -56,7 +56,7 @@
     permanent: true
     immediate: true
     state: disabled
-    zone: "{{ firewalld_default_zone|default('public') }}"
+    zone: "{{ default_zone|default('public') }}"
   with_items: "{{ active_services.stdout_lines }}"
   when: firewalld_purge_services and item not in firewalld_service_rules
   tags: firewalld
@@ -75,7 +75,7 @@
     permanent: true
     immediate: true
     state: disabled
-    zone: "{{ firewalld_default_zone|default('public') }}"
+    zone: "{{ default_zone|default('public') }}"
   with_items: "{{ active_ports.stdout_lines }}"
   when: firewalld_purge_services and item not in firewalld_service_rules
   tags: firewalld


### PR DESCRIPTION
I added to possibility to purge all unconfigured ports and also renamed the dafault_zone variable to be more inline with other variables. 