### PR TITLE
Allow specify list of source IPs for zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The following variables are used to define the source of a zone:
 ```
     firewalld_zone_source:
       public:
-        source: (required, e.g. "192.168.1.0/24")
+        source: 
+         - (required, e.g. "192.168.1.0/24")
         state: (optional, only values: enabled|disabled, default: enabled)
         permanent: (optional, only values: true|false, default: true)
         immediate: (optional, only values: true|false, default: true)
@@ -131,8 +132,10 @@ Example Playbook
           internal: eth1
           internal: eth2
         firewalld_zone_source:
-          trusted:
-            source: "192.168.1.0/24"
+          - name: trusted
+            source: 
+              - 192.168.1.0/24
+              - 192.168.2.0/24
             state: enabled
             permanent: true
             immediate: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
   register: result
   when: defaultzone.stdout != default_zone
   changed_when: result.stdout == "success"
+  notify: restart firewalld
   tags: firewalld
 
 - name: set firewalld zone interfaces
@@ -36,12 +37,15 @@
 
 - name: set firewalld zone source
   firewalld:
-    zone: "{{ item.key }}"
-    permanent: "{{ item.value.permanent|default('true') }}"
-    immediate: "{{ item.value.immediate|default('true') }}"
-    state: "{{ item.value.state|default('enabled') }}"
-    source: "{{ item.value.source }}"
-  with_dict: "{{ firewalld_zone_source|default({}) }}"
+    zone: "{{ item.0.name }}"
+    permanent: "{{ item.0.permanent|default('true') }}"
+    immediate: "{{ item.0.immediate|default('true') }}"
+    state: "{{ item.0.state|default('enabled') }}"
+    source: "{{ item.1 }}"
+  with_subelements:
+    - "{{ firewalld_zone_source|default({}) }}"
+    - source
+  notify: restart firewalld
   tags: firewalld
 
 - name: get active firewalld service rules


### PR DESCRIPTION
For example:
```
 firewalld_zone_source:
   - name: trusted
     source: 
       - 192.168.1.0/24
       - 192.168.2.0/24
     state: enabled
     permanent: true
     immediate: true
```